### PR TITLE
chore: prevent canary release in PR from forked repo [by push]

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -50,7 +50,12 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
+    if: |
+      (!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')) &&
+      (
+        (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+        github.event_name == 'push'
+      )
     needs: unit-test
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
# What Changed

## Motivation

## Change Type

Indicate the type of change your pull request is:

- [ ] `documentation`
- [ ] `patch`
- [ ] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-assets -->
:baby_chick: Download canary assets:

[nexus--canary.5.4508731066.zip](https://github.com/nexus-backup/nexus/releases/download/v0.0.0-canary/nexus--canary.5.4508731066.zip)
<!-- GITHUB_RELEASE PR BODY: canary-assets -->
